### PR TITLE
feat: portfolio polish, validation and GitHub Pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - develop
+      - main
   push:
     branches:
       - develop
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Build project
+        run: npm run build -- --base=/image-gallery-app/
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,84 +1,68 @@
 # Image Gallery App
 
-A responsive image gallery built with **React**, **TypeScript**, **Vite**, **Tailwind CSS**, **Framer Motion**, and **Drag and Drop**.
-
-The app allows users to upload images, search through the gallery, edit image details, delete items, reorder cards with drag and drop, and persist data locally using the browser storage.
+Portfolio-ready image gallery built with **React 19**, **TypeScript**, **Vite**, **Tailwind CSS 4**, **Framer Motion**, drag and drop, and local browser persistence.
 
 ## Features
 
-- Upload images from the local device.
-- Search images by title or description.
-- Edit image title and description.
-- Delete images from the gallery.
-- Reorder images with drag and drop.
-- Persist gallery data in local storage.
-- Toggle between light and dark mode.
-- Display image details in a modal.
-- Show animated interactions with Framer Motion.
+- Responsive visual gallery with polished cards and animated interactions.
+- Upload images with file type and size validation.
+- Search by title, description, and category.
+- Filter by category and favorite images.
+- Sort by manual order, title, recent upload, or favorites.
+- Edit title, description, and category in a detailed modal.
+- Show image metadata such as file name, size, type, dimensions, date, and favorite state.
+- Delete images with an undo action.
+- Import and export gallery backups as JSON.
+- Recover safely if localStorage contains invalid data.
+- Persist light and dark mode.
+- Run lint and build checks with GitHub Actions.
+- Deploy from `develop` with GitHub Pages Actions.
 
 ## Tech Stack
 
-- React 19
+- React
 - TypeScript
 - Vite
-- Tailwind CSS 4
+- Tailwind CSS
 - Framer Motion
 - @hello-pangea/dnd
 - React Hot Toast
-- Lucide React
+- GitHub Actions
 
-## Installation
+## Git Flow
 
-Clone the repository:
-
-```bash
-git clone https://github.com/NoisGit/image-gallery-app.git
-cd image-gallery-app
+```text
+main      -> production-ready branch
+develop   -> integration branch and GitHub Pages deploy source
+feature/* -> feature work branches
 ```
 
-Install dependencies:
+Recommended flow:
+
+```text
+feature/* -> develop -> main
+```
+
+## Deployment
+
+GitHub Pages deploy is configured in `.github/workflows/deploy.yml` and runs on every push to `develop`.
+
+Expected site after the first successful deploy:
+
+```text
+https://noisgit.github.io/image-gallery-app/
+```
+
+If Pages is not enabled yet, set the repository Pages source to **GitHub Actions**.
+
+## Local Development
 
 ```bash
 npm install
-```
-
-Run the development server:
-
-```bash
 npm run dev
-```
-
-## Available Scripts
-
-```bash
-npm run dev
-npm run build
 npm run lint
-npm run preview
+npm run build
 ```
-
-## Project Structure
-
-```text
-src/
-├── components/
-├── context/
-├── data/
-├── assets/
-├── App.tsx
-└── main.tsx
-```
-
-## Roadmap
-
-- Add image categories.
-- Add favorite images.
-- Add image metadata.
-- Add import/export support.
-- Add automated tests.
-- Add CI workflow.
-- Improve accessibility.
-- Improve mobile layout.
 
 ## Author
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+import { Toaster } from "react-hot-toast";
 import { ThemeContext } from "./context/ThemeContext";
 import Gallery from "./components/Gallery";
 import Header from "./components/Header";
@@ -9,33 +10,31 @@ export default function App() {
 
   return (
     <div
-      className={`min-h-screen flex flex-col transition-colors duration-300
-        ${theme === "dark"
+      className={`relative flex min-h-screen w-full flex-col overflow-x-hidden transition-colors duration-300 ${
+        theme === "dark"
           ? "bg-zinc-950 text-zinc-100"
-          : "bg-gradient-to-br from-white via-white to-pink-100 text-zinc-900"
-        } w-full`}
-      style={{
-        minWidth: "100vw",
-        width: "100vw",
-        overflowX: "hidden",
-        boxSizing: "border-box",
-      }}
+          : "bg-[radial-gradient(circle_at_top_left,#fce7f3_0,#ffffff_34%,#f5f3ff_68%,#fff7ed_100%)] text-zinc-900"
+      }`}
     >
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div className="absolute left-1/2 top-0 h-96 w-96 -translate-x-1/2 rounded-full bg-pink-300/30 blur-3xl dark:bg-pink-700/20" />
+        <div className="absolute bottom-10 right-0 h-96 w-96 rounded-full bg-violet-300/25 blur-3xl dark:bg-violet-700/20" />
+      </div>
+
       <Header />
-      <main
-        className="
-          flex-1 flex flex-col items-center justify-start
-          px-4 py-6 w-full
-          overflow-y-auto
-          scrollbar-thin scrollbar-thumb-pink-200 dark:scrollbar-thumb-zinc-700
-        "
-        style={{
-          width: "100%",
-        }}
-      >
+      <main className="flex flex-1 justify-center px-4 py-8 sm:px-6 lg:px-8">
         <Gallery />
       </main>
       <Footer />
+
+      <Toaster
+        position="top-right"
+        toastOptions={{
+          duration: 3500,
+          className:
+            "!rounded-2xl !border !border-zinc-200 !bg-white !px-4 !py-3 !text-sm !font-semibold !text-zinc-800 !shadow-xl dark:!border-zinc-700 dark:!bg-zinc-900 dark:!text-zinc-100",
+        }}
+      />
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,41 +1,29 @@
 export default function Footer() {
   return (
-    <footer className="w-full py-5 mt-auto bg-zinc-900/90 dark:bg-zinc-950/90 border-t border-zinc-800 text-zinc-300 flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-10 text-sm">
-      <span className="font-semibold">© {new Date().getFullYear()} Image Gallery App</span>
-      <div className="flex gap-5">
-        <a
-          href="https://github.com/NoisGIT"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-pink-400 transition"
-          aria-label="GitHub"
-        >
-          <svg width="22" height="22" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 2C6.477 2 2 6.484 2 12.021c0 4.428 2.867 8.183 6.839 9.504.5.09.682-.216.682-.481 0-.237-.008-.868-.013-1.703-2.782.604-3.37-1.34-3.37-1.34-.454-1.157-1.11-1.465-1.11-1.465-.908-.62.069-.608.069-.608 1.004.071 1.532 1.033 1.532 1.033.892 1.528 2.341 1.087 2.91.832.09-.646.35-1.087.636-1.338-2.221-.253-4.555-1.114-4.555-4.951 0-1.093.39-1.987 1.029-2.687-.103-.253-.447-1.273.098-2.656 0 0 .84-.27 2.75 1.025A9.564 9.564 0 0 1 12 6.844a9.61 9.61 0 0 1 2.506.338c1.91-1.295 2.748-1.025 2.748-1.025.547 1.383.203 2.403.1 2.656.64.7 1.028 1.594 1.028 2.687 0 3.847-2.337 4.696-4.566 4.944.36.31.682.924.682 1.863 0 1.345-.012 2.429-.012 2.758 0 .267.18.576.688.478C19.137 20.2 22 16.447 22 12.021 22 6.484 17.523 2 12 2z"/>
-          </svg>
-        </a>
-        <a
-          href="https://www.linkedin.com/in/borisalvialv/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-pink-400 transition"
-          aria-label="LinkedIn"
-        >
-          <svg width="22" height="22" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M4.98 3.5C3.32 3.5 2 4.82 2 6.48c0 1.64 1.3 2.98 2.96 2.98h.03c1.67 0 2.98-1.34 2.98-2.98C7.97 4.82 6.65 3.5 4.98 3.5zM2.4 21.5h5.17v-9.54H2.4v9.54zM9.61 12.1v9.4h5.17v-5.22c0-1.34.03-3.06 1.87-3.06 1.86 0 2.15 1.45 2.15 2.95v5.33h5.17v-5.72c0-2.76-.59-4.89-3.77-4.89-1.54 0-2.58.85-3.01 1.65h-.04v-1.41H9.61zm-4.81 0H4.8v9.4h5.17v-9.4z"/>
-          </svg>
-        </a>
-        <a
-          href="https://www.instagram.com/Nois.DeuS"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-pink-400 transition"
-          aria-label="Instagram"
-        >
-          <svg width="22" height="22" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 2.163c3.204 0 3.584.012 4.849.07 1.366.062 2.633.336 3.608 1.311.975.975 1.249 2.242 1.311 3.608.058 1.265.069 1.645.069 4.849s-.012 3.584-.07 4.849c-.062 1.366-.336 2.633-1.311 3.608-.975.975-2.242 1.249-3.608 1.311-1.265.058-1.645.069-4.849.069s-3.584-.012-4.849-.07c-1.366-.062-2.633-.336-3.608-1.311-.975-.975-1.249-2.242-1.311-3.608C2.175 15.646 2.163 15.266 2.163 12s.012-3.584.07-4.849c.062-1.366.336-2.633 1.311-3.608.975-.975 2.242-1.249 3.608-1.311C8.416 2.175 8.796 2.163 12 2.163zm0-2.163C8.741 0 8.333.015 7.052.073 5.771.131 4.635.385 3.678 1.343c-.957.957-1.211 2.093-1.269 3.374C2.015 5.667 2 6.076 2 12s.015 6.333.073 7.605c.058 1.281.312 2.417 1.269 3.374.957.957 2.093 1.211 3.374 1.269C8.333 23.985 8.741 24 12 24s3.667-.015 4.948-.073c1.281-.058 2.417-.312 3.374-1.269.957-.957 1.211-2.093 1.269-3.374.058-1.272.073-1.681.073-7.605s-.015-6.333-.073-7.605c-.058-1.281-.312-2.417-1.269-3.374C19.365.385 18.229.131 16.948.073 15.667.015 15.259 0 12 0zm0 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zm0 10.162a3.999 3.999 0 1 1 0-7.997 3.999 3.999 0 0 1 0 7.997zm6.406-11.845a1.44 1.44 0 1 0 0 2.882 1.44 1.44 0 0 0 0-2.882z"/>
-          </svg>
-        </a>
+    <footer className="mt-auto w-full border-t border-white/60 bg-white/70 py-6 text-sm text-zinc-500 backdrop-blur-xl dark:border-zinc-800 dark:bg-zinc-950/70 dark:text-zinc-400">
+      <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-4 text-center sm:flex-row sm:px-6 lg:px-8">
+        <span className="font-semibold">
+          © {new Date().getFullYear()} Image Gallery App · Hecho con React, TypeScript y Vite
+        </span>
+
+        <div className="flex items-center gap-4">
+          <a
+            href="https://github.com/NoisGit/image-gallery-app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-black text-zinc-700 transition hover:text-pink-500 dark:text-zinc-200"
+          >
+            GitHub
+          </a>
+          <a
+            href="https://www.linkedin.com/in/borisalvialv/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-black text-zinc-700 transition hover:text-pink-500 dark:text-zinc-200"
+          >
+            LinkedIn
+          </a>
+        </div>
       </div>
     </footer>
   );

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,251 +1,471 @@
-import { useState, useEffect } from "react";
-import type { ChangeEvent } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { ChangeEvent, KeyboardEvent } from "react";
+import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
+import type { DropResult } from "@hello-pangea/dnd";
+import { AnimatePresence, motion } from "framer-motion";
+import toast from "react-hot-toast";
 import { images as initialImages, type ImageData } from "../data/images";
+import {
+  CATEGORY_OPTIONS,
+  DEFAULT_CATEGORY,
+  getErrorMessage,
+  getTitleFromFileName,
+  loadImagesFromStorage,
+  normalizeImages,
+  sanitizeText,
+  saveImagesToStorage,
+  sortImages,
+  validateImageDetails,
+  validateImageFile,
+} from "../utils/gallery";
+import type { Category, SortMode } from "../utils/gallery";
 import ImageCard from "./ImageCard";
 import ImageModal from "./ImageModal";
-import { motion, AnimatePresence } from "framer-motion";
-import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
-import type { DropResult } from "@hello-pangea/dnd";
-import toast from "react-hot-toast";
 
 const STORAGE_KEY = "image_gallery_items";
 
-function getInitialImages(): ImageData[] {
-  const savedImages = localStorage.getItem(STORAGE_KEY);
-  return savedImages ? JSON.parse(savedImages) : initialImages;
+type DeletedImage = {
+  image: ImageData;
+  index: number;
+};
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("No se pudo leer la imagen."));
+    reader.readAsDataURL(file);
+  });
 }
 
 export default function Gallery() {
-  const [images, setImages] = useState<ImageData[]>(getInitialImages());
+  const [initialState] = useState(() => loadImagesFromStorage(STORAGE_KEY, initialImages));
+  const [images, setImages] = useState<ImageData[]>(initialState.images);
   const [search, setSearch] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<Category | "all">("all");
+  const [sortMode, setSortMode] = useState<SortMode>("manual");
+  const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
-  const [selectedImage, setSelectedImage] = useState<ImageData | null>(null);
+  const [selectedImageId, setSelectedImageId] = useState<number | null>(null);
   const [uploading, setUploading] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [storageRecovered, setStorageRecovered] = useState(initialState.recovered);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const storageErrorShownRef = useRef(false);
+  const lastDeletedRef = useRef<DeletedImage | null>(null);
+  const undoTimeoutRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(images));
-  }, [images]);
-
-  const filtered = images.filter((img) =>
-    (img.title + img.description).toLowerCase().includes(search.toLowerCase())
+  const selectedImage = useMemo(
+    () => images.find((image) => image.id === selectedImageId) ?? null,
+    [images, selectedImageId],
   );
 
-  const openModal = (img: ImageData) => {
-    setSelectedImage(img);
+  const displayedImages = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const filteredImages = images.filter((image) => {
+      const text = `${image.title} ${image.description} ${image.category ?? ""}`.toLowerCase();
+      const matchesText = text.includes(query);
+      const matchesCategory = categoryFilter === "all" || image.category === categoryFilter;
+      const matchesFavorite = !showFavoritesOnly || Boolean(image.isFavorite);
+      return matchesText && matchesCategory && matchesFavorite;
+    });
+
+    return sortImages(filteredImages, sortMode);
+  }, [categoryFilter, images, search, showFavoritesOnly, sortMode]);
+
+  const totalFavorites = images.filter((image) => image.isFavorite).length;
+  const hasActiveFilters = Boolean(search.trim()) || categoryFilter !== "all" || showFavoritesOnly;
+
+  useEffect(() => {
+    if (!storageRecovered) return;
+    toast.error("Se restauró la galería porque había datos guardados inválidos.");
+    setStorageRecovered(false);
+  }, [storageRecovered]);
+
+  useEffect(() => {
+    const error = saveImagesToStorage(STORAGE_KEY, images);
+    if (error && !storageErrorShownRef.current) {
+      toast.error(error);
+      storageErrorShownRef.current = true;
+    }
+  }, [images]);
+
+  useEffect(() => {
+    return () => {
+      if (undoTimeoutRef.current) window.clearTimeout(undoTimeoutRef.current);
+    };
+  }, []);
+
+  const resetUploadInput = () => {
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const resetImportInput = () => {
+    if (importInputRef.current) importInputRef.current.value = "";
+  };
+
+  const openModal = (image: ImageData) => {
+    setSelectedImageId(image.id);
     setModalOpen(true);
   };
 
-  const closeModal = () => setModalOpen(false);
-
-  const saveChanges = (id: number, newTitle: string, newDesc: string) => {
-    setImages((imgs) =>
-      imgs.map((img) =>
-        img.id === id ? { ...img, title: newTitle, description: newDesc } : img
-      )
-    );
-    toast.success("Cambios guardados");
+  const closeModal = () => {
     setModalOpen(false);
+    setSelectedImageId(null);
+  };
+
+  const saveChanges = (id: number, newTitle: string, newDescription: string, newCategory: Category) => {
+    const validation = validateImageDetails(newTitle, newDescription);
+    if (!validation.ok) {
+      toast.error(validation.message ?? "Revisa los datos de la imagen.");
+      return;
+    }
+
+    setImages((currentImages) =>
+      currentImages.map((image) =>
+        image.id === id
+          ? {
+              ...image,
+              title: sanitizeText(newTitle, 60),
+              description: sanitizeText(newDescription, 180),
+              category: newCategory,
+            }
+          : image,
+      ),
+    );
+
+    toast.success("Cambios guardados");
+    closeModal();
+  };
+
+  const restoreDeletedImage = () => {
+    const deleted = lastDeletedRef.current;
+    if (!deleted) return;
+
+    setImages((currentImages) => {
+      if (currentImages.some((image) => image.id === deleted.image.id)) return currentImages;
+      const restoredImages = [...currentImages];
+      restoredImages.splice(Math.min(deleted.index, restoredImages.length), 0, deleted.image);
+      return restoredImages;
+    });
+
+    lastDeletedRef.current = null;
+    toast.success("Imagen restaurada");
   };
 
   const deleteImage = (id: number) => {
-    setImages((imgs) => imgs.filter((img) => img.id !== id));
-    toast("Imagen eliminada", { icon: "🗑️" });
-    setModalOpen(false);
+    setImages((currentImages) => {
+      const imageIndex = currentImages.findIndex((image) => image.id === id);
+      if (imageIndex === -1) return currentImages;
+      lastDeletedRef.current = { image: currentImages[imageIndex], index: imageIndex };
+      return currentImages.filter((image) => image.id !== id);
+    });
+
+    if (undoTimeoutRef.current) window.clearTimeout(undoTimeoutRef.current);
+    undoTimeoutRef.current = window.setTimeout(() => {
+      lastDeletedRef.current = null;
+    }, 6500);
+
+    toast(
+      (toastItem) => (
+        <span className="flex items-center gap-3">
+          Imagen eliminada
+          <button
+            type="button"
+            onClick={() => {
+              restoreDeletedImage();
+              toast.dismiss(toastItem.id);
+            }}
+            className="rounded-full bg-zinc-950 px-3 py-1 text-xs font-bold text-white transition hover:bg-pink-600 dark:bg-white dark:text-zinc-950"
+          >
+            Deshacer
+          </button>
+        </span>
+      ),
+      { duration: 6000, icon: "🗑️" },
+    );
+
+    closeModal();
   };
 
-  const handleUpload = async (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
+  const toggleFavorite = (id: number) => {
+    setImages((currentImages) =>
+      currentImages.map((image) => (image.id === id ? { ...image, isFavorite: !image.isFavorite } : image)),
+    );
+  };
+
+  const handleUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
     if (!file) return;
+
     setUploading(true);
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const isDuplicate = images.some(
-        (img) =>
-          img.title === file.name.replace(/\.\w+$/, "") &&
-          img.url === reader.result
-      );
-      if (isDuplicate) {
-        toast.error("¡Esta imagen ya fue subida!");
-        setUploading(false);
-        return;
-      }
+
+    try {
+      const validation = validateImageFile(file);
+      if (!validation.ok) throw new Error(validation.message);
+
+      const dataUrl = await readFileAsDataUrl(file);
+      const isDuplicate = images.some((image) => image.url === dataUrl || image.originalName === file.name);
+      if (isDuplicate) throw new Error("Esta imagen ya existe en la galería.");
+
       const newImage: ImageData = {
         id: Date.now(),
-        title: file.name.replace(/\.\w+$/, ""),
+        title: getTitleFromFileName(file.name),
         description: "Haz clic para editar la descripción.",
-        url: reader.result as string,
+        url: dataUrl,
+        category: "Personal",
+        isFavorite: false,
+        originalName: file.name,
+        size: file.size,
+        mimeType: file.type,
+        uploadedAt: new Date().toISOString(),
       };
-      setImages((imgs) => [newImage, ...imgs]);
+
+      setImages((currentImages) => [newImage, ...currentImages]);
       toast.success("Imagen subida");
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+    } finally {
       setUploading(false);
+      resetUploadInput();
+    }
+  };
+
+  const exportGallery = () => {
+    const backup = {
+      app: "image-gallery-app",
+      version: 2,
+      exportedAt: new Date().toISOString(),
+      images,
     };
-    reader.readAsDataURL(file);
+    const blob = new Blob([JSON.stringify(backup, null, 2)], { type: "application/json;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `image-gallery-backup-${new Date().toISOString().slice(0, 10)}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+    toast.success("Backup exportado");
+  };
+
+  const handleImport = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setImporting(true);
+
+    try {
+      const parsed = JSON.parse(await file.text()) as unknown;
+      const candidate = parsed && typeof parsed === "object" && "images" in parsed ? (parsed as { images: unknown }).images : parsed;
+      const importedImages = normalizeImages(candidate);
+      if (!Array.isArray(candidate) || (candidate.length > 0 && importedImages.length === 0)) {
+        throw new Error("El archivo no tiene una galería válida.");
+      }
+
+      setImages(importedImages);
+      toast.success(`Galería importada (${importedImages.length} imágenes)`);
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+    } finally {
+      setImporting(false);
+      resetImportInput();
+    }
+  };
+
+  const clearFilters = () => {
+    setSearch("");
+    setCategoryFilter("all");
+    setShowFavoritesOnly(false);
+    setSortMode("manual");
   };
 
   const onDragEnd = (result: DropResult) => {
     if (!result.destination) return;
-    const reordered = Array.from(filtered);
+
+    if (sortMode !== "manual") {
+      toast.error("Vuelve al orden manual para arrastrar imágenes.");
+      return;
+    }
+
+    const reordered = Array.from(displayedImages);
     const [removed] = reordered.splice(result.source.index, 1);
     reordered.splice(result.destination.index, 0, removed);
 
-    if (filtered.length !== images.length) {
-      const newImages = [...images];
+    if (displayedImages.length !== images.length) {
+      const nextImages = [...images];
       const filteredIndexes = images
-        .map((img, idx) => (filtered.find((f) => f.id === img.id) ? idx : -1))
-        .filter((idx) => idx !== -1);
+        .map((image, index) => (displayedImages.some((item) => item.id === image.id) ? index : -1))
+        .filter((index) => index !== -1);
 
-      filteredIndexes.forEach((imgIdx, i) => {
-        newImages[imgIdx] = reordered[i];
+      filteredIndexes.forEach((imageIndex, index) => {
+        nextImages[imageIndex] = reordered[index];
       });
-      setImages(newImages);
+      setImages(nextImages);
     } else {
       setImages(reordered);
     }
+
     toast.success("Imágenes reordenadas");
   };
 
+  const handleCardKeyDown = (event: KeyboardEvent<HTMLDivElement>, image: ImageData) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    openModal(image);
+  };
+
   return (
-    <section className="w-full max-w-6xl mx-auto flex flex-col items-center justify-center">
-      <div className="w-full flex flex-col gap-2 mb-6">
-        <div className="w-full flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+    <section className="w-full max-w-7xl">
+      <motion.div
+        className="relative mb-8 overflow-hidden rounded-[2rem] border border-white/70 bg-white/75 p-6 shadow-2xl shadow-pink-200/40 backdrop-blur-xl dark:border-zinc-800 dark:bg-zinc-900/80 dark:shadow-black/40 sm:p-8"
+        initial={{ opacity: 0, y: 18 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.35 }}
+      >
+        <div className="pointer-events-none absolute -right-24 -top-24 h-56 w-56 rounded-full bg-pink-300/40 blur-3xl dark:bg-pink-700/30" />
+        <div className="pointer-events-none absolute -bottom-24 -left-24 h-56 w-56 rounded-full bg-violet-300/40 blur-3xl dark:bg-violet-700/30" />
+
+        <div className="relative grid gap-6 lg:grid-cols-[1.05fr_0.95fr] lg:items-end">
+          <div>
+            <span className="mb-3 inline-flex rounded-full bg-pink-100 px-4 py-1.5 text-xs font-black uppercase tracking-[0.2em] text-pink-700 dark:bg-pink-500/15 dark:text-pink-200">
+              Portfolio gallery
+            </span>
+            <h1 className="max-w-3xl text-4xl font-black tracking-tight text-zinc-950 dark:text-white sm:text-5xl">
+              Galería visual con filtros, favoritos y persistencia local.
+            </h1>
+            <p className="mt-4 max-w-2xl text-base leading-7 text-zinc-600 dark:text-zinc-300">
+              Sube imágenes, ordénalas, edita sus datos, respáldalas en JSON y mantén una experiencia cuidada para escritorio y mobile.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3 text-center">
+            <StatCard label="Imágenes" value={images.length} />
+            <StatCard label="Favoritas" value={totalFavorites} />
+            <StatCard label="Visibles" value={displayedImages.length} />
+          </div>
+        </div>
+      </motion.div>
+
+      <div className="mb-8 rounded-[1.5rem] border border-white/70 bg-white/80 p-4 shadow-xl shadow-pink-100/50 backdrop-blur dark:border-zinc-800 dark:bg-zinc-900/75 dark:shadow-black/30 sm:p-5">
+        <div className="grid gap-3 lg:grid-cols-[1.3fr_0.8fr_0.8fr_auto]">
           <input
             type="text"
-            placeholder="Buscar imágenes..."
+            placeholder="Buscar por título, descripción o categoría..."
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="rounded-lg border border-zinc-300 dark:border-zinc-700 px-4 py-2.5
-                       bg-zinc-900 text-zinc-100 dark:bg-zinc-900 dark:text-zinc-100
-                       focus:outline-pink-400 transition shadow
-                       w-full sm:w-[370px] h-[46px] flex-shrink-0"
-            style={{ minHeight: 46, maxHeight: 46 }}
+            onChange={(event) => setSearch(event.target.value)}
+            className="h-12 w-full rounded-2xl border border-zinc-200 bg-white px-4 text-zinc-900 shadow-sm transition placeholder:text-zinc-400 focus:border-pink-400 focus:outline-none focus:ring-4 focus:ring-pink-200/70 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100 dark:placeholder:text-zinc-500 dark:focus:ring-pink-500/20"
+            aria-label="Buscar imágenes"
           />
-          <motion.label
-            whileTap={{ scale: 0.96 }}
-            className="flex items-center justify-center gap-2 cursor-pointer px-5 py-2.5
-                      rounded-lg bg-pink-500 hover:bg-pink-600 text-white text-sm font-semibold
-                      transition shadow disabled:opacity-60 h-[46px] min-w-[160px] flex-shrink-0"
-            style={{ minHeight: 46, maxHeight: 46 }}
+
+          <select
+            value={categoryFilter}
+            onChange={(event) => setCategoryFilter(event.target.value as Category | "all")}
+            className="h-12 w-full rounded-2xl border border-zinc-200 bg-white px-4 text-zinc-900 shadow-sm transition focus:border-pink-400 focus:outline-none focus:ring-4 focus:ring-pink-200/70 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100 dark:focus:ring-pink-500/20"
+            aria-label="Filtrar por categoría"
           >
-            {uploading ? (
-              <motion.span
-                key="loading"
-                initial={{ opacity: 0, scale: 0.95 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.95 }}
-                transition={{ duration: 0.15 }}
-              >
-                Cargando...
-              </motion.span>
-            ) : (
-              <>
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="w-5 h-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    d="M12 16V4m0 0L8 8m4-4 4 4M4 20h16"
-                  />
-                </svg>
-                Subir imagen
-              </>
+            <option value="all">Todas las categorías</option>
+            {CATEGORY_OPTIONS.map((category) => (
+              <option key={category} value={category}>{category}</option>
+            ))}
+          </select>
+
+          <select
+            value={sortMode}
+            onChange={(event) => setSortMode(event.target.value as SortMode)}
+            className="h-12 w-full rounded-2xl border border-zinc-200 bg-white px-4 text-zinc-900 shadow-sm transition focus:border-pink-400 focus:outline-none focus:ring-4 focus:ring-pink-200/70 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100 dark:focus:ring-pink-500/20"
+            aria-label="Ordenar imágenes"
+          >
+            <option value="manual">Orden manual</option>
+            <option value="title">Título A-Z</option>
+            <option value="uploadedAt">Más recientes</option>
+            <option value="favorites">Favoritas primero</option>
+          </select>
+
+          <button
+            type="button"
+            onClick={() => setShowFavoritesOnly((value) => !value)}
+            className={`h-12 rounded-2xl px-5 text-sm font-black shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pink-400 ${
+              showFavoritesOnly
+                ? "bg-pink-500 text-white hover:bg-pink-600"
+                : "bg-zinc-100 text-zinc-700 hover:bg-pink-100 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
+            }`}
+            aria-pressed={showFavoritesOnly}
+          >
+            ♥ Favoritas
+          </button>
+        </div>
+
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+          <div className="flex flex-wrap gap-2">
+            <motion.label whileTap={{ scale: 0.97 }} className="inline-flex h-11 cursor-pointer items-center justify-center rounded-2xl bg-pink-500 px-5 text-sm font-black text-white shadow-lg shadow-pink-300/40 transition hover:bg-pink-600 dark:shadow-pink-950/40">
+              {uploading ? "Cargando..." : "+ Subir imagen"}
+              <input ref={fileInputRef} type="file" accept="image/jpeg,image/png,image/webp" onChange={handleUpload} className="hidden" disabled={uploading} />
+            </motion.label>
+
+            <button type="button" onClick={exportGallery} className="h-11 rounded-2xl bg-zinc-950 px-5 text-sm font-black text-white shadow-sm transition hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pink-400 dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200">
+              Exportar JSON
+            </button>
+
+            <motion.label whileTap={{ scale: 0.97 }} className="inline-flex h-11 cursor-pointer items-center justify-center rounded-2xl bg-zinc-100 px-5 text-sm font-black text-zinc-700 shadow-sm transition hover:bg-pink-100 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700">
+              {importing ? "Importando..." : "Importar JSON"}
+              <input ref={importInputRef} type="file" accept="application/json,.json" onChange={handleImport} className="hidden" disabled={importing} />
+            </motion.label>
+          </div>
+
+          <div className="flex items-center gap-3 text-sm font-semibold text-zinc-500 dark:text-zinc-400">
+            <span>{displayedImages.length} / {images.length} visibles</span>
+            {hasActiveFilters && (
+              <button type="button" onClick={clearFilters} className="rounded-full px-3 py-1 text-pink-600 transition hover:bg-pink-100 dark:text-pink-300 dark:hover:bg-pink-500/10">
+                Limpiar filtros
+              </button>
             )}
-            <input
-              type="file"
-              accept="image/*"
-              onChange={handleUpload}
-              className="hidden"
-              disabled={uploading}
-            />
-          </motion.label>
-        </div>
-        <div className="w-full flex justify-end">
-          <span className="text-zinc-500 dark:text-zinc-300 text-sm px-1 select-none">
-            {filtered.length} / {images.length}
-          </span>
+          </div>
         </div>
       </div>
-      <div className="w-full flex justify-center">
-        <motion.div layout className="w-full">
-          <DragDropContext onDragEnd={onDragEnd}>
-            <Droppable droppableId="gallery">
-              {(provided) => (
-                <div
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
-                  className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 w-full"
-                >
-                  <AnimatePresence>
-                    {filtered.length === 0 ? (
-                      <motion.div
-                        className="col-span-full text-center py-10 text-zinc-400 dark:text-zinc-200"
-                        key="noresult"
-                        initial={{ opacity: 0, y: 16 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        exit={{ opacity: 0, y: 16 }}
-                      >
-                        Sin resultados 😢
-                      </motion.div>
-                    ) : (
-                      filtered.map((img, idx) => (
-                        <Draggable
-                          key={img.id}
-                          draggableId={img.id.toString()}
-                          index={idx}
-                        >
-                          {(draggableProvided, snapshot) => (
-                            <div
-                              ref={draggableProvided.innerRef}
-                              {...draggableProvided.draggableProps}
-                              {...draggableProvided.dragHandleProps}
-                              style={{
-                                ...draggableProvided.draggableProps.style,
-                                zIndex: snapshot.isDragging ? 30 : 1,
-                                cursor: snapshot.isDragging ? "grabbing" : "grab",
-                              }}
-                              onClick={() => openModal(img)}
-                            >
-                              <motion.div
-                                layout
-                                initial={{ opacity: 0, scale: 0.97, y: 18 }}
-                                animate={{
-                                  opacity: 1,
-                                  scale: snapshot.isDragging ? 1.06 : 1,
-                                  y: 0,
-                                  boxShadow: snapshot.isDragging
-                                    ? "0 6px 40px 0 #fbc2eb99"
-                                    : "0 2px 12px 0 #e9a9ea11",
-                                }}
-                                exit={{ opacity: 0, scale: 0.97, y: 18 }}
-                                transition={{ duration: 0.18 }}
-                              >
-                                <ImageCard image={img} />
-                              </motion.div>
-                            </div>
-                          )}
-                        </Draggable>
-                      ))
-                    )}
-                  </AnimatePresence>
-                  {provided.placeholder}
-                </div>
-              )}
-            </Droppable>
-          </DragDropContext>
-        </motion.div>
-      </div>
-      {selectedImage && (
-        <ImageModal
-          image={selectedImage}
-          isOpen={modalOpen}
-          onClose={closeModal}
-          onSave={saveChanges}
-          onDelete={deleteImage}
-        />
-      )}
+
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Droppable droppableId="gallery">
+          {(provided) => (
+            <div ref={provided.innerRef} {...provided.droppableProps} className="grid grid-cols-1 gap-7 sm:grid-cols-2 xl:grid-cols-3">
+              <AnimatePresence>
+                {displayedImages.length === 0 ? (
+                  <motion.div key="empty-state" className="col-span-full rounded-[2rem] border border-dashed border-pink-300 bg-white/70 p-10 text-center shadow-lg shadow-pink-100/50 dark:border-pink-700/60 dark:bg-zinc-900/70 dark:shadow-black/30" initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: 16 }}>
+                    <span className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-pink-100 text-3xl dark:bg-pink-500/15">{images.length === 0 ? "📸" : "🔎"}</span>
+                    <h2 className="text-2xl font-black text-zinc-950 dark:text-white">{images.length === 0 ? "Tu galería está vacía" : "No encontramos resultados"}</h2>
+                    <p className="mx-auto mt-3 max-w-md text-sm leading-6 text-zinc-500 dark:text-zinc-400">{images.length === 0 ? "Sube tu primera imagen para comenzar." : "Prueba limpiando filtros o usando otra palabra."}</p>
+                    {hasActiveFilters && <button type="button" onClick={clearFilters} className="mt-5 rounded-2xl bg-pink-500 px-5 py-2.5 text-sm font-black text-white transition hover:bg-pink-600">Limpiar filtros</button>}
+                  </motion.div>
+                ) : (
+                  displayedImages.map((image, index) => (
+                    <Draggable key={image.id} draggableId={image.id.toString()} index={index} isDragDisabled={sortMode !== "manual"}>
+                      {(draggableProvided, snapshot) => (
+                        <div ref={draggableProvided.innerRef} {...draggableProvided.draggableProps} {...draggableProvided.dragHandleProps} role="button" tabIndex={0} aria-label={`Abrir detalle de ${image.title}`} onKeyDown={(event) => handleCardKeyDown(event, image)} onClick={() => openModal(image)} className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-pink-400" style={{ ...draggableProvided.draggableProps.style, zIndex: snapshot.isDragging ? 30 : 1, cursor: sortMode === "manual" ? (snapshot.isDragging ? "grabbing" : "grab") : "pointer" }}>
+                          <motion.div layout initial={{ opacity: 0, scale: 0.97, y: 18 }} animate={{ opacity: 1, scale: snapshot.isDragging ? 1.04 : 1, y: 0 }} exit={{ opacity: 0, scale: 0.97, y: 18 }} transition={{ duration: 0.18 }}>
+                            <ImageCard image={image} onToggleFavorite={toggleFavorite} />
+                          </motion.div>
+                        </div>
+                      )}
+                    </Draggable>
+                  ))
+                )}
+              </AnimatePresence>
+              {provided.placeholder}
+            </div>
+          )}
+        </Droppable>
+      </DragDropContext>
+
+      {selectedImage && <ImageModal image={selectedImage} isOpen={modalOpen} onClose={closeModal} onSave={saveChanges} onDelete={deleteImage} fallbackCategory={DEFAULT_CATEGORY} />}
     </section>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-white/80 p-4 shadow-sm dark:border-zinc-700 dark:bg-zinc-950/50">
+      <strong className="block text-3xl font-black text-pink-500">{value}</strong>
+      <span className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">{label}</span>
+    </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,29 +5,30 @@ export default function Header() {
   const { theme, toggleTheme } = useContext(ThemeContext);
 
   return (
-    <header className="sticky top-0 z-30 w-full bg-zinc-900/90 dark:bg-zinc-950/90 border-b border-zinc-800 shadow-lg backdrop-blur-md">
-      <div className="max-w-6xl mx-auto flex items-center justify-between px-6 sm:px-12" style={{ height: "72px" }}>
-        <div className="flex items-center gap-2">
-          <span className="flex items-center" style={{ lineHeight: 1, marginBottom: "2px" }}>
-            <svg width="34" height="34" viewBox="0 0 24 24" fill="none" style={{ display: "block" }}>
-              <rect x="3" y="7" width="18" height="12" rx="2.5" fill="#eee" />
-              <rect x="1" y="5" width="22" height="16" rx="3" fill="#a78bfa" />
-              <circle cx="12" cy="13" r="4" fill="#2d2d32" />
-              <circle cx="12" cy="13" r="2" fill="#a5b4fc" />
-              <rect x="7" y="2" width="10" height="4" rx="2" fill="#e0e7ff" />
-            </svg>
+    <header className="sticky top-0 z-40 w-full border-b border-white/60 bg-white/75 shadow-sm backdrop-blur-xl dark:border-zinc-800 dark:bg-zinc-950/75">
+      <div className="mx-auto flex h-20 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+        <a href="#top" className="flex items-center gap-3" aria-label="Ir al inicio">
+          <span className="grid h-12 w-12 place-items-center rounded-2xl bg-gradient-to-br from-pink-500 to-violet-500 text-2xl shadow-lg shadow-pink-300/40 dark:shadow-pink-950/40">
+            📷
           </span>
-          <span className="font-black text-2xl sm:text-3xl tracking-tight text-pink-500 select-none" style={{ lineHeight: 1, paddingTop: "2px" }}>
-            Image Gallery
+          <span>
+            <span className="block text-lg font-black leading-none text-zinc-950 dark:text-white sm:text-2xl">
+              Image Gallery
+            </span>
+            <span className="hidden text-xs font-bold uppercase tracking-[0.2em] text-pink-500 sm:block">
+              React portfolio app
+            </span>
           </span>
-        </div>
+        </a>
+
         <button
+          type="button"
           onClick={toggleTheme}
-          aria-label="Cambiar tema"
-          className="w-11 h-11 rounded-full flex items-center justify-center bg-zinc-200 dark:bg-zinc-800 hover:bg-pink-200 dark:hover:bg-pink-700 shadow-md transition text-2xl"
-          tabIndex={0}
+          aria-label={theme === "dark" ? "Cambiar a modo claro" : "Cambiar a modo oscuro"}
+          className="flex h-12 items-center gap-2 rounded-2xl border border-zinc-200 bg-white px-4 text-sm font-black text-zinc-800 shadow-sm transition hover:border-pink-300 hover:bg-pink-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pink-400 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800"
         >
-          {theme === "dark" ? "☀️" : "🌙"}
+          <span aria-hidden="true">{theme === "dark" ? "☀️" : "🌙"}</span>
+          <span className="hidden sm:inline">{theme === "dark" ? "Claro" : "Oscuro"}</span>
         </button>
       </div>
     </header>

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -1,22 +1,58 @@
+import type { MouseEvent } from "react";
 import type { ImageData } from "../data/images";
+import { formatDate } from "../utils/gallery";
 
 interface Props {
   image: ImageData;
+  onToggleFavorite: (id: number) => void;
 }
 
-export default function ImageCard({ image }: Props) {
+export default function ImageCard({ image, onToggleFavorite }: Props) {
+  const handleFavoriteClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onToggleFavorite(image.id);
+  };
+
   return (
-    <div className="group relative rounded-2xl shadow-lg overflow-hidden bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 hover:shadow-2xl hover:scale-[1.02] transition-all cursor-pointer flex flex-col">
+    <article className="group relative min-h-[22rem] overflow-hidden rounded-[1.75rem] border border-white/60 bg-white/80 shadow-xl shadow-pink-200/30 ring-1 ring-zinc-950/5 backdrop-blur transition duration-300 hover:-translate-y-1 hover:shadow-2xl hover:shadow-pink-300/30 dark:border-zinc-700/80 dark:bg-zinc-900/80 dark:shadow-black/30">
       <img
         src={image.url}
         alt={image.title}
-        className="w-full h-56 object-cover transition group-hover:brightness-90"
+        className="h-72 w-full object-cover transition duration-500 group-hover:scale-105 group-hover:brightness-95"
         loading="lazy"
       />
-      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent flex flex-col justify-end p-4">
-        <h3 className="text-lg font-extrabold text-white drop-shadow">{image.title}</h3>
-        <p className="text-sm text-zinc-100">{image.description}</p>
+
+      <button
+        type="button"
+        onClick={handleFavoriteClick}
+        className={`absolute right-4 top-4 flex h-11 w-11 items-center justify-center rounded-full border text-xl shadow-lg backdrop-blur transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pink-400 ${
+          image.isFavorite
+            ? "border-pink-200 bg-pink-500 text-white hover:bg-pink-600"
+            : "border-white/70 bg-zinc-950/40 text-white hover:bg-zinc-950/60"
+        }`}
+        aria-label={image.isFavorite ? "Quitar de favoritas" : "Marcar como favorita"}
+        aria-pressed={Boolean(image.isFavorite)}
+      >
+        {image.isFavorite ? "♥" : "♡"}
+      </button>
+
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-zinc-950 via-zinc-950/75 to-transparent p-5 pt-24 text-white">
+        <div className="mb-3 flex flex-wrap gap-2">
+          <span className="rounded-full bg-white/15 px-3 py-1 text-xs font-semibold backdrop-blur">
+            {image.category ?? "Sin categoría"}
+          </span>
+          {image.uploadedAt && (
+            <span className="rounded-full bg-white/15 px-3 py-1 text-xs font-semibold backdrop-blur">
+              {formatDate(image.uploadedAt)}
+            </span>
+          )}
+        </div>
+
+        <h3 className="text-xl font-black leading-tight drop-shadow-sm">{image.title}</h3>
+        <p className="gallery-clamp-2 mt-2 text-sm leading-6 text-zinc-100/90">
+          {image.description}
+        </p>
       </div>
-    </div>
+    </article>
   );
 }

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -1,96 +1,194 @@
-import { useState, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ImageData } from "../data/images";
 import { motion, AnimatePresence } from "framer-motion";
+import { CATEGORY_OPTIONS, formatDate, formatFileSize, isCategory } from "../utils/gallery";
+import type { Category } from "../utils/gallery";
 
 interface Props {
   image: ImageData;
   isOpen: boolean;
+  fallbackCategory: Category;
   onClose: () => void;
-  onSave: (id: number, newTitle: string, newDesc: string) => void;
+  onSave: (id: number, newTitle: string, newDescription: string, newCategory: Category) => void;
   onDelete: (id: number) => void;
 }
 
-export default function ImageModal({
-  image,
-  isOpen,
-  onClose,
-  onSave,
-  onDelete,
-}: Props) {
+export default function ImageModal({ image, isOpen, fallbackCategory, onClose, onSave, onDelete }: Props) {
   const [title, setTitle] = useState(image.title);
-  const [desc, setDesc] = useState(image.description);
+  const [description, setDescription] = useState(image.description);
+  const [category, setCategory] = useState<Category>(isCategory(image.category) ? image.category : fallbackCategory);
   const inputRef = useRef<HTMLInputElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const originalCategory = useMemo(
+    () => (isCategory(image.category) ? image.category : fallbackCategory),
+    [fallbackCategory, image.category],
+  );
+
+  const hasChanges = title !== image.title || description !== image.description || category !== originalCategory;
 
   useEffect(() => {
     setTitle(image.title);
-    setDesc(image.description);
-    if (isOpen && inputRef.current) inputRef.current.focus();
-    if (isOpen) document.body.style.overflow = "hidden";
-    else document.body.style.overflow = "";
-    return () => { document.body.style.overflow = ""; };
-  }, [isOpen, image]);
+    setDescription(image.description);
+    setCategory(originalCategory);
+  }, [image, originalCategory]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    document.body.style.overflow = "hidden";
+    window.setTimeout(() => inputRef.current?.focus(), 0);
+
+    return () => {
+      document.body.style.overflow = "";
+      previousFocusRef.current?.focus();
+    };
+  }, [isOpen]);
+
+  const requestClose = useCallback(() => {
+    if (hasChanges && !window.confirm("Tienes cambios sin guardar. ¿Cerrar de todos modos?")) return;
+    onClose();
+  }, [hasChanges, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") requestClose();
+    };
+
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [isOpen, requestClose]);
 
   if (!isOpen) return null;
+
+  const dimensions = image.width && image.height ? `${image.width} × ${image.height}px` : "No disponible";
 
   return (
     <AnimatePresence>
       <motion.div
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-3"
+        className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-zinc-950/75 p-3 backdrop-blur-md sm:p-6"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        onClick={onClose}
+        onClick={requestClose}
       >
         <motion.div
-          className="bg-white dark:bg-zinc-900 rounded-2xl shadow-xl max-w-sm w-full p-6 relative flex flex-col items-center"
-          initial={{ scale: 0.96, opacity: 0, y: 50 }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="image-modal-title"
+          className="relative grid max-h-[92vh] w-full max-w-5xl overflow-hidden rounded-[2rem] border border-white/20 bg-white shadow-2xl dark:border-zinc-800 dark:bg-zinc-950 lg:grid-cols-[1.1fr_0.9fr]"
+          initial={{ scale: 0.96, opacity: 0, y: 40 }}
           animate={{ scale: 1, opacity: 1, y: 0 }}
-          exit={{ scale: 0.96, opacity: 0, y: 50 }}
+          exit={{ scale: 0.96, opacity: 0, y: 40 }}
           transition={{ type: "spring", bounce: 0.18, duration: 0.28 }}
-          onClick={e => e.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
         >
           <button
-            onClick={onClose}
-            className="absolute top-3 right-3 text-zinc-500 hover:text-pink-500 text-2xl"
-            aria-label="Cerrar"
+            type="button"
+            onClick={requestClose}
+            className="absolute right-4 top-4 z-10 flex h-11 w-11 items-center justify-center rounded-full bg-white/90 text-2xl font-bold text-zinc-700 shadow-lg transition hover:bg-pink-100 hover:text-pink-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pink-400 dark:bg-zinc-900/90 dark:text-zinc-100 dark:hover:bg-zinc-800"
+            aria-label="Cerrar modal"
           >
             ×
           </button>
-          <img
-            src={image.url}
-            alt={title}
-            className="w-full h-56 object-cover rounded-xl mb-5 shadow"
-          />
-          <input
-            ref={inputRef}
-            value={title}
-            onChange={e => setTitle(e.target.value)}
-            className="mb-2 px-3 py-2 w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 text-lg font-bold text-zinc-900 dark:text-zinc-100 focus:outline-pink-400 transition"
-            placeholder="Título"
-          />
-          <textarea
-            value={desc}
-            onChange={e => setDesc(e.target.value)}
-            className="mb-3 px-3 py-2 w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 text-sm text-zinc-800 dark:text-zinc-100 focus:outline-pink-400 transition resize-none"
-            rows={3}
-            placeholder="Descripción"
-          />
-          <div className="flex w-full gap-2 mt-2">
-            <button
-              className="flex-1 py-2 rounded-lg bg-pink-500 hover:bg-pink-600 text-white font-semibold transition"
-              onClick={() => onSave(image.id, title, desc)}
+
+          <div className="min-h-[18rem] bg-zinc-950 lg:min-h-[34rem]">
+            <img src={image.url} alt={title} className="h-full max-h-[40vh] w-full object-cover lg:max-h-none" />
+          </div>
+
+          <div className="overflow-y-auto p-5 sm:p-7">
+            <span className="mb-3 inline-flex rounded-full bg-pink-100 px-3 py-1 text-xs font-black uppercase tracking-[0.18em] text-pink-700 dark:bg-pink-500/15 dark:text-pink-200">
+              Detalle de imagen
+            </span>
+
+            <label className="mb-2 block text-sm font-bold text-zinc-600 dark:text-zinc-300" htmlFor="image-title">
+              Título
+            </label>
+            <input
+              id="image-title"
+              ref={inputRef}
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              maxLength={60}
+              className="mb-4 w-full rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-xl font-black text-zinc-950 transition focus:border-pink-400 focus:outline-none focus:ring-4 focus:ring-pink-200/70 dark:border-zinc-700 dark:bg-zinc-900 dark:text-white dark:focus:ring-pink-500/20"
+              placeholder="Título"
+            />
+
+            <label className="mb-2 block text-sm font-bold text-zinc-600 dark:text-zinc-300" htmlFor="image-description">
+              Descripción
+            </label>
+            <textarea
+              id="image-description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              maxLength={180}
+              className="mb-4 min-h-28 w-full resize-none rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm leading-6 text-zinc-800 transition focus:border-pink-400 focus:outline-none focus:ring-4 focus:ring-pink-200/70 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:ring-pink-500/20"
+              rows={4}
+              placeholder="Descripción"
+            />
+
+            <label className="mb-2 block text-sm font-bold text-zinc-600 dark:text-zinc-300" htmlFor="image-category">
+              Categoría
+            </label>
+            <select
+              id="image-category"
+              value={category}
+              onChange={(event) => setCategory(event.target.value as Category)}
+              className="mb-5 w-full rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm font-semibold text-zinc-900 transition focus:border-pink-400 focus:outline-none focus:ring-4 focus:ring-pink-200/70 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:ring-pink-500/20"
             >
-              Guardar
-            </button>
-            <button
-              className="flex-1 py-2 rounded-lg bg-zinc-200 hover:bg-zinc-300 text-zinc-800 dark:bg-zinc-700 dark:text-white dark:hover:bg-zinc-600 font-semibold transition"
-              onClick={() => onDelete(image.id)}
-            >
-              Eliminar
-            </button>
+              {CATEGORY_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+
+            <div className="mb-5 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <MetadataItem label="Archivo" value={image.originalName ?? "No disponible"} />
+              <MetadataItem label="Peso" value={formatFileSize(image.size)} />
+              <MetadataItem label="Formato" value={image.mimeType ?? "No disponible"} />
+              <MetadataItem label="Dimensiones" value={dimensions} />
+              <MetadataItem label="Fecha" value={formatDate(image.uploadedAt)} />
+              <MetadataItem label="Favorita" value={image.isFavorite ? "Sí" : "No"} />
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                className="flex-1 rounded-2xl bg-pink-500 px-5 py-3 text-sm font-black text-white shadow-lg shadow-pink-300/40 transition hover:bg-pink-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pink-400 dark:shadow-pink-950/40"
+                onClick={() => onSave(image.id, title, description, category)}
+              >
+                Guardar cambios
+              </button>
+              <button
+                type="button"
+                className="flex-1 rounded-2xl bg-zinc-100 px-5 py-3 text-sm font-black text-zinc-700 transition hover:bg-red-100 hover:text-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-400 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-red-500/10 dark:hover:text-red-300"
+                onClick={() => onDelete(image.id)}
+              >
+                Eliminar
+              </button>
+            </div>
+
+            {hasChanges && (
+              <p className="mt-4 rounded-2xl bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-800 dark:bg-amber-500/10 dark:text-amber-200">
+                Tienes cambios sin guardar.
+              </p>
+            )}
           </div>
         </motion.div>
       </motion.div>
     </AnimatePresence>
+  );
+}
+
+function MetadataItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900/80">
+      <span className="block text-xs font-black uppercase tracking-[0.16em] text-zinc-400">{label}</span>
+      <span className="mt-1 block break-words text-sm font-bold text-zinc-800 dark:text-zinc-100">{value}</span>
+    </div>
   );
 }

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -7,13 +7,24 @@ type ThemeContextType = {
   toggleTheme: () => void;
 };
 
+const THEME_STORAGE_KEY = "image_gallery_theme";
+
+function getInitialTheme(): Theme {
+  if (typeof window === "undefined") return "light";
+
+  const savedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (savedTheme === "light" || savedTheme === "dark") return savedTheme;
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
 export const ThemeContext = createContext<ThemeContextType>({
   theme: "light",
   toggleTheme: () => {},
 });
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [theme, setTheme] = useState<Theme>("light");
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
 
   const toggleTheme = () => {
     setTheme((prev) => (prev === "light" ? "dark" : "light"));
@@ -21,18 +32,11 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     const root = window.document.documentElement;
-    if (theme === "dark") {
-      root.classList.add("dark");
-    } else {
-      root.classList.remove("dark");
-    }
+    root.classList.toggle("dark", theme === "dark");
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
-  return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
-      {children}
-    </ThemeContext.Provider>
-  );
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
 };
 
 export const useTheme = () => useContext(ThemeContext);

--- a/src/data/images.ts
+++ b/src/data/images.ts
@@ -3,61 +3,126 @@ export type ImageData = {
   title: string;
   description: string;
   url: string;
+  category?: string;
+  isFavorite?: boolean;
+  originalName?: string;
+  size?: number;
+  mimeType?: string;
+  uploadedAt?: string;
+  width?: number;
+  height?: number;
 };
 
 export const images: ImageData[] = [
   {
     id: 1,
     title: "Montaña Rosa",
-    description: "Amanecer increíble en las montañas.",
-    url: "https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80"
+    description: "Amanecer suave entre montañas y tonos pastel.",
+    url: "https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1200&q=80",
+    category: "Paisaje",
+    isFavorite: true,
+    originalName: "montana-rosa.jpg",
+    mimeType: "image/jpeg",
+    uploadedAt: "2026-03-20T09:30:00.000Z",
+    width: 1200,
+    height: 800,
   },
   {
     id: 2,
     title: "Ciudad Nocturna",
-    description: "Luces y movimiento por la noche.",
-    url: "https://images.unsplash.com/photo-1465101046530-73398c7f28ca?auto=format&fit=crop&w=800&q=80"
+    description: "Luces urbanas, contraste y movimiento por la noche.",
+    url: "https://images.unsplash.com/photo-1465101046530-73398c7f28ca?auto=format&fit=crop&w=1200&q=80",
+    category: "Ciudad",
+    originalName: "ciudad-nocturna.jpg",
+    mimeType: "image/jpeg",
+    uploadedAt: "2026-03-22T21:10:00.000Z",
+    width: 1200,
+    height: 800,
   },
   {
     id: 3,
     title: "Playa Tranquila",
-    description: "Relajo junto al mar.",
-    url: "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=80"
+    description: "Una escena limpia y relajada junto al mar.",
+    url: "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1200&q=80",
+    category: "Viajes",
+    isFavorite: true,
+    originalName: "playa-tranquila.jpg",
+    mimeType: "image/jpeg",
+    uploadedAt: "2026-03-24T12:00:00.000Z",
+    width: 1200,
+    height: 800,
   },
   {
     id: 4,
     title: "Bosque Encantado",
-    description: "Verde y naturaleza a full.",
-    url: "https://images.unsplash.com/photo-1465101178521-c1a9136a3fd7?auto=format&fit=crop&w=800&q=80"
+    description: "Verde profundo, naturaleza y ambiente de calma.",
+    url: "https://images.unsplash.com/photo-1465101178521-c1a9136a3fd7?auto=format&fit=crop&w=1200&q=80",
+    category: "Naturaleza",
+    originalName: "bosque-encantado.jpg",
+    mimeType: "image/jpeg",
+    uploadedAt: "2026-03-26T15:45:00.000Z",
+    width: 1200,
+    height: 800,
   },
   {
     id: 5,
     title: "Vía Láctea",
-    description: "Cielo estrellado en el desierto.",
-    url: "https://images.unsplash.com/photo-1462331940025-496dfbfc7564?auto=format&fit=crop&w=800&q=80"
+    description: "Cielo estrellado con una vibra cinematográfica.",
+    url: "https://images.unsplash.com/photo-1462331940025-496dfbfc7564?auto=format&fit=crop&w=1200&q=80",
+    category: "Paisaje",
+    originalName: "via-lactea.jpg",
+    mimeType: "image/jpeg",
+    uploadedAt: "2026-03-28T02:20:00.000Z",
+    width: 1200,
+    height: 800,
   },
   {
     id: 6,
     title: "Lago Espejado",
-    description: "Paisaje y reflejo perfecto.",
-    url: "https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=800&q=80"
+    description: "Reflejo perfecto para una galería visual y elegante.",
+    url: "https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=80",
+    category: "Naturaleza",
+    originalName: "lago-espejado.jpg",
+    mimeType: "image/jpeg",
+    uploadedAt: "2026-03-30T10:00:00.000Z",
+    width: 1200,
+    height: 800,
   },
   {
     id: 7,
     title: "Atardecer Urbano",
-    description: "Colores intensos en la ciudad.",
-    url: "https://images.unsplash.com/photo-1519125323398-675f0ddb6308?auto=format&fit=crop&w=800&q=80"
+    description: "Colores intensos sobre edificios y calles activas.",
+    url: "https://images.unsplash.com/photo-1519125323398-675f0ddb6308?auto=format&fit=crop&w=1200&q=80",
+    category: "Ciudad",
+    originalName: "atardecer-urbano.jpg",
+    mimeType: "image/jpeg",
+    uploadedAt: "2026-04-01T19:05:00.000Z",
+    width: 1200,
+    height: 800,
   },
   {
     id: 8,
     title: "Montaña Nevada",
-    description: "Frío y naturaleza.",
-    url: "https://images.unsplash.com/photo-1464820453369-31d2c0b651af?auto=format&fit=crop&w=800&q=80"
+    description: "Texturas frías, nieve y una vista limpia de invierno.",
+    url: "https://images.unsplash.com/photo-1464820453369-31d2c0b651af?auto=format&fit=crop&w=1200&q=80",
+    category: "Paisaje",
+    originalName: "montana-nevada.jpg",
+    mimeType: "image/jpeg",
+    uploadedAt: "2026-04-03T08:25:00.000Z",
+    width: 1200,
+    height: 800,
   },
   {
     id: 9,
     title: "Jardín Japonés",
-    description: "Tranquilidad y paz entre árboles y agua.",
-    url: "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=800&q=80"
-  }
+    description: "Paz visual, agua y vegetación con estética delicada.",
+    url: "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80",
+    category: "Viajes",
+    isFavorite: true,
+    originalName: "jardin-japones.jpg",
+    mimeType: "image/jpeg",
+    uploadedAt: "2026-04-05T11:40:00.000Z",
+    width: 1200,
+    height: 800,
+  },
 ];

--- a/src/index.css
+++ b/src/index.css
@@ -1,87 +1,90 @@
 @import "tailwindcss";
 
-html, body, #root {
-  height: 100%;
-  min-height: 100vh;
-  width: 100vw;
-  margin: 0 !important;
-  padding: 0 !important;
+* {
   box-sizing: border-box;
-  overflow-x: hidden;
-  max-width: 100vw;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
-  font-family: 'Inter', sans-serif;
-  background: #f5f5f5;
-  color: #18181b;
-  transition: background 0.3s, color 0.3s;
-  scrollbar-width: none;
-}
-
-.dark body {
-  background: #18181b;
-  color: #f5f5f5;
-}
-
-#root {
   min-height: 100vh;
-  width: 100vw;
+  overflow-x: hidden;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #fff7fb;
+  color: #18181b;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
 }
 
-input[type="text"], input[type="file"], textarea {
-  border-radius: 0.5rem;
-  outline: none;
-  transition: border 0.2s, box-shadow 0.2s;
-  font-size: 1rem;
-  font-family: inherit;
-  box-sizing: border-box;
+button,
+input,
+textarea,
+select {
+  font: inherit;
 }
 
-input:focus, textarea:focus {
-  border-color: #e879f9 !important;
-  box-shadow: 0 0 0 2px #f9a8d4cc;
+button,
+label,
+select {
+  -webkit-tap-highlight-color: transparent;
 }
 
-input[type="file"] {
-  padding: 0;
-  background: none;
-  border: none;
+button:disabled,
+input:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
-main {
-  scrollbar-width: thin;
-  scrollbar-color: #fbc2eb55 transparent;
+::selection {
+  background: #f9a8d4;
+  color: #3f1230;
 }
 
-main::-webkit-scrollbar {
-  width: 8px;
-  background: transparent;
-}
-main::-webkit-scrollbar-thumb {
-  background: #fbc2eb55;
-  border-radius: 10px;
-}
-
-body::-webkit-scrollbar, #root::-webkit-scrollbar {
-  width: 0 !important;
-  background: transparent !important;
-}
-
-button, label, select {
-  outline: none;
-  font-family: inherit;
-  transition: background 0.2s, box-shadow 0.2s, color 0.2s;
-  border-radius: 0.5rem;
-}
-
-/* Placeholder visible en dark */
 ::placeholder {
-  color: #cbd5e1;
+  color: #94a3b8;
   opacity: 1;
 }
 
 .dark ::placeholder {
-  color: #a3a3a3;
-  opacity: 1;
+  color: #71717a;
+}
+
+.gallery-clamp-2 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #f9a8d4;
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background-clip: content-box;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: #52525b;
+  border: 3px solid transparent;
+  background-clip: content-box;
 }

--- a/src/utils/gallery.ts
+++ b/src/utils/gallery.ts
@@ -1,0 +1,6 @@
+export const MAX_UPLOAD_SIZE_MB = 6;
+export const MAX_UPLOAD_SIZE_BYTES = MAX_UPLOAD_SIZE_MB * 1024 * 1024;
+export const CATEGORY_OPTIONS = ["Paisaje", "Ciudad", "Naturaleza", "Viajes", "Personal", "Otro"] as const;
+export const DEFAULT_CATEGORY = "Paisaje";
+export type Category = (typeof CATEGORY_OPTIONS)[number];
+export type SortMode = "manual" | "title" | "uploadedAt" | "favorites";

--- a/src/utils/gallery.ts
+++ b/src/utils/gallery.ts
@@ -1,6 +1,204 @@
+import type { ImageData } from "../data/images";
+
 export const MAX_UPLOAD_SIZE_MB = 6;
 export const MAX_UPLOAD_SIZE_BYTES = MAX_UPLOAD_SIZE_MB * 1024 * 1024;
+export const SUPPORTED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
 export const CATEGORY_OPTIONS = ["Paisaje", "Ciudad", "Naturaleza", "Viajes", "Personal", "Otro"] as const;
 export const DEFAULT_CATEGORY = "Paisaje";
+
 export type Category = (typeof CATEGORY_OPTIONS)[number];
 export type SortMode = "manual" | "title" | "uploadedAt" | "favorites";
+
+type StorageLoadResult = {
+  images: ImageData[];
+  recovered: boolean;
+};
+
+type ValidationResult = {
+  ok: boolean;
+  message?: string;
+};
+
+export function isCategory(value: unknown): value is Category {
+  return typeof value === "string" && CATEGORY_OPTIONS.includes(value as Category);
+}
+
+export function sanitizeText(value: unknown, maxLength: number): string {
+  if (typeof value !== "string") return "";
+
+  return value
+    .replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
+export function getTitleFromFileName(fileName: string): string {
+  const withoutExtension = fileName.replace(/\.[^/.]+$/, "");
+  const normalized = withoutExtension.replace(/[-_]+/g, " ").replace(/\s+/g, " ").trim();
+
+  return normalized || "Nueva imagen";
+}
+
+export function isSafeImageUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  if (value.startsWith("data:image/")) return true;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function readString(source: Record<string, unknown>, key: string, fallback = ""): string {
+  return typeof source[key] === "string" ? source[key] : fallback;
+}
+
+function readNumber(source: Record<string, unknown>, key: string): number | undefined {
+  return typeof source[key] === "number" && Number.isFinite(source[key]) ? source[key] : undefined;
+}
+
+function readBoolean(source: Record<string, unknown>, key: string): boolean {
+  return typeof source[key] === "boolean" ? source[key] : false;
+}
+
+export function normalizeImageData(value: unknown, index: number): ImageData | null {
+  if (!value || typeof value !== "object") return null;
+
+  const source = value as Record<string, unknown>;
+  const url = readString(source, "url");
+
+  if (!isSafeImageUrl(url)) return null;
+
+  const rawId = readNumber(source, "id");
+  const uploadedAt = readString(source, "uploadedAt");
+
+  return {
+    id: rawId ?? Date.now() + index,
+    title: sanitizeText(readString(source, "title", "Nueva imagen"), 60) || "Nueva imagen",
+    description: sanitizeText(readString(source, "description", "Sin descripción."), 180) || "Sin descripción.",
+    url,
+    category: isCategory(source.category) ? source.category : DEFAULT_CATEGORY,
+    isFavorite: readBoolean(source, "isFavorite"),
+    originalName: sanitizeText(readString(source, "originalName"), 120) || undefined,
+    size: readNumber(source, "size"),
+    mimeType: sanitizeText(readString(source, "mimeType"), 40) || undefined,
+    uploadedAt: Number.isNaN(Date.parse(uploadedAt)) ? undefined : uploadedAt,
+    width: readNumber(source, "width"),
+    height: readNumber(source, "height"),
+  };
+}
+
+export function normalizeImages(value: unknown): ImageData[] {
+  if (!Array.isArray(value)) return [];
+
+  const usedIds = new Set<number>();
+
+  return value.reduce<ImageData[]>((items, item, index) => {
+    const normalized = normalizeImageData(item, index);
+    if (!normalized) return items;
+
+    if (usedIds.has(normalized.id)) {
+      normalized.id = Date.now() + index;
+    }
+
+    usedIds.add(normalized.id);
+    items.push(normalized);
+    return items;
+  }, []);
+}
+
+export function loadImagesFromStorage(storageKey: string, fallback: ImageData[]): StorageLoadResult {
+  if (typeof window === "undefined") {
+    return { images: normalizeImages(fallback), recovered: false };
+  }
+
+  const rawValue = window.localStorage.getItem(storageKey);
+  if (!rawValue) return { images: normalizeImages(fallback), recovered: false };
+
+  try {
+    const parsed = JSON.parse(rawValue) as unknown;
+    if (!Array.isArray(parsed)) throw new Error("Invalid gallery data");
+
+    const normalized = normalizeImages(parsed);
+    return { images: normalized, recovered: normalized.length !== parsed.length };
+  } catch {
+    window.localStorage.removeItem(storageKey);
+    return { images: normalizeImages(fallback), recovered: true };
+  }
+}
+
+export function saveImagesToStorage(storageKey: string, images: ImageData[]): string | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(images));
+    return null;
+  } catch {
+    return "No se pudo guardar la galería. Prueba eliminando imágenes pesadas.";
+  }
+}
+
+export function validateImageFile(file: File): ValidationResult {
+  if (!SUPPORTED_IMAGE_TYPES.includes(file.type)) {
+    return { ok: false, message: "Formato no permitido. Usa imágenes JPG, PNG o WEBP." };
+  }
+
+  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+    return { ok: false, message: `La imagen supera los ${MAX_UPLOAD_SIZE_MB}MB permitidos.` };
+  }
+
+  return { ok: true };
+}
+
+export function validateImageDetails(title: string, description: string): ValidationResult {
+  if (sanitizeText(title, 60).length < 2) {
+    return { ok: false, message: "El título debe tener al menos 2 caracteres." };
+  }
+
+  if (sanitizeText(description, 180).length < 4) {
+    return { ok: false, message: "La descripción debe tener al menos 4 caracteres." };
+  }
+
+  return { ok: true };
+}
+
+export function sortImages(images: ImageData[], sortMode: SortMode): ImageData[] {
+  const items = [...images];
+
+  if (sortMode === "title") {
+    return items.sort((a, b) => a.title.localeCompare(b.title, "es", { sensitivity: "base" }));
+  }
+
+  if (sortMode === "uploadedAt") {
+    return items.sort((a, b) => (Date.parse(b.uploadedAt ?? "") || 0) - (Date.parse(a.uploadedAt ?? "") || 0));
+  }
+
+  if (sortMode === "favorites") {
+    return items.sort((a, b) => Number(Boolean(b.isFavorite)) - Number(Boolean(a.isFavorite)));
+  }
+
+  return items;
+}
+
+export function formatFileSize(size?: number): string {
+  if (!size) return "No disponible";
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+export function formatDate(date?: string): string {
+  if (!date || Number.isNaN(Date.parse(date))) return "No disponible";
+
+  return new Intl.DateTimeFormat("es-CL", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(date));
+}
+
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Ocurrió un error inesperado.";
+}


### PR DESCRIPTION
## Resumen

- Mejora visual completa para dejar la galería más presentable como proyecto de portafolio.
- Agrega categorías, favoritos, filtros, ordenamiento, metadata, estados vacíos y modal de detalle más completo.
- Agrega validación de subida por tipo/tamaño, recuperación segura de localStorage e import/export JSON.
- Agrega workflow de deploy a GitHub Pages desde `develop`.
- Ajusta CI para validar PRs y pushes hacia `develop` y `main`.

## Flujo

`feature/portfolio-polish-deploy` -> `develop` -> `main`

## Issues relacionadas

Refs #2, #3, #4, #5, #6, #9, #12, #13, #14, #15, #17, #19, #20.

## Pendiente posterior

- Tests unitarios base (#7).
- Capturas reales para el README (#18).
- Compresión avanzada con canvas (#16).