### PR TITLE
feat: compress uploaded images before saving

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -19,6 +19,7 @@ import {
   validateImageFile,
 } from "../utils/gallery";
 import type { Category, SortMode } from "../utils/gallery";
+import { compressImageFile } from "../utils/imageCompression";
 import ImageCard from "./ImageCard";
 import ImageModal from "./ImageModal";
 
@@ -28,15 +29,6 @@ type DeletedImage = {
   image: ImageData;
   index: number;
 };
-
-function readFileAsDataUrl(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = () => reject(new Error("No se pudo leer la imagen."));
-    reader.readAsDataURL(file);
-  });
-}
 
 export default function Gallery() {
   const [initialState] = useState(() => loadImagesFromStorage(STORAGE_KEY, initialImages));
@@ -205,27 +197,30 @@ export default function Gallery() {
       const validation = validateImageFile(file);
       if (!validation.ok) throw new Error(validation.message);
 
-      const dataUrl = await readFileAsDataUrl(file);
-      const isDuplicate = images.some((image) => image.url === dataUrl || image.originalName === file.name);
+      toast.loading("Optimizando imagen...", { id: "image-upload" });
+      const compressedImage = await compressImageFile(file);
+      const isDuplicate = images.some((image) => image.originalName === file.name || image.url === compressedImage.dataUrl);
       if (isDuplicate) throw new Error("Esta imagen ya existe en la galería.");
 
       const newImage: ImageData = {
         id: Date.now(),
         title: getTitleFromFileName(file.name),
         description: "Haz clic para editar la descripción.",
-        url: dataUrl,
+        url: compressedImage.dataUrl,
         category: "Personal",
         isFavorite: false,
         originalName: file.name,
-        size: file.size,
-        mimeType: file.type,
+        size: compressedImage.size,
+        mimeType: compressedImage.mimeType,
         uploadedAt: new Date().toISOString(),
+        width: compressedImage.width,
+        height: compressedImage.height,
       };
 
       setImages((currentImages) => [newImage, ...currentImages]);
-      toast.success("Imagen subida");
+      toast.success("Imagen optimizada y subida", { id: "image-upload" });
     } catch (error) {
-      toast.error(getErrorMessage(error));
+      toast.error(getErrorMessage(error), { id: "image-upload" });
     } finally {
       setUploading(false);
       resetUploadInput();
@@ -399,7 +394,7 @@ export default function Gallery() {
         <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <div className="flex flex-wrap gap-2">
             <motion.label whileTap={{ scale: 0.97 }} className="inline-flex h-11 cursor-pointer items-center justify-center rounded-2xl bg-pink-500 px-5 text-sm font-black text-white shadow-lg shadow-pink-300/40 transition hover:bg-pink-600 dark:shadow-pink-950/40">
-              {uploading ? "Cargando..." : "+ Subir imagen"}
+              {uploading ? "Optimizando..." : "+ Subir imagen"}
               <input ref={fileInputRef} type="file" accept="image/jpeg,image/png,image/webp" onChange={handleUpload} className="hidden" disabled={uploading} />
             </motion.label>
 

--- a/src/utils/imageCompression.ts
+++ b/src/utils/imageCompression.ts
@@ -1,0 +1,85 @@
+export const MAX_COMPRESSED_WIDTH = 1600;
+export const IMAGE_COMPRESSION_QUALITY = 0.82;
+export const OUTPUT_IMAGE_TYPE = "image/webp";
+
+type CompressedImageResult = {
+  dataUrl: string;
+  width: number;
+  height: number;
+  size: number;
+  mimeType: string;
+};
+
+function readBlobAsDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("No se pudo preparar la imagen comprimida."));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(file);
+    const image = new Image();
+
+    image.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve(image);
+    };
+
+    image.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error("El archivo no pudo cargarse como imagen."));
+    };
+
+    image.src = objectUrl;
+  });
+}
+
+function createOutputBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("No se pudo comprimir la imagen."));
+          return;
+        }
+
+        resolve(blob);
+      },
+      OUTPUT_IMAGE_TYPE,
+      IMAGE_COMPRESSION_QUALITY,
+    );
+  });
+}
+
+export async function compressImageFile(file: File): Promise<CompressedImageResult> {
+  const image = await loadImage(file);
+  const scale = Math.min(MAX_COMPRESSED_WIDTH / image.naturalWidth, 1);
+  const width = Math.max(1, Math.round(image.naturalWidth * scale));
+  const height = Math.max(1, Math.round(image.naturalHeight * scale));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Tu navegador no pudo preparar la compresión.");
+  }
+
+  context.drawImage(image, 0, 0, width, height);
+
+  const blob = await createOutputBlob(canvas);
+  const dataUrl = await readBlobAsDataUrl(blob);
+
+  return {
+    dataUrl,
+    width,
+    height,
+    size: blob.size,
+    mimeType: blob.type || OUTPUT_IMAGE_TYPE,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a browser image compression helper using canvas.
- Compresses uploaded images to WebP before storing them in localStorage.
- Stores compressed size, output MIME type, width and height metadata.
- Updates upload feedback from loading to optimizing.

## Related issue

Closes #16