### PR TITLE
docs: add visual README previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
 
 Portfolio-ready image gallery built with **React 19**, **TypeScript**, **Vite**, **Tailwind CSS 4**, **Framer Motion**, drag and drop, and local browser persistence.
 
+## Preview
+
+![Light mode gallery preview](docs/preview/gallery-light.svg)
+
+![Dark mode gallery preview](docs/preview/gallery-dark.svg)
+
+![Image detail modal preview](docs/preview/gallery-modal.svg)
+
 ## Features
 
 - Responsive visual gallery with polished cards and animated interactions.
 - Upload images with file type and size validation.
+- Compress uploaded images before storing them locally.
 - Search by title, description, and category.
 - Filter by category and favorite images.
 - Sort by manual order, title, recent upload, or favorites.

--- a/docs/preview/gallery-dark.svg
+++ b/docs/preview/gallery-dark.svg
@@ -1,0 +1,60 @@
+<svg width="1200" height="760" viewBox="0 0 1200 760" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Image Gallery App dark preview</title>
+  <desc id="desc">Portfolio gallery preview with dark theme, filters, cards and stats.</desc>
+  <rect width="1200" height="760" rx="36" fill="#09090B"/>
+  <circle cx="1040" cy="120" r="220" fill="#831843" opacity="0.38"/>
+  <circle cx="120" cy="670" r="240" fill="#4C1D95" opacity="0.42"/>
+  <rect x="56" y="42" width="1088" height="72" rx="24" fill="#18181B" opacity="0.92" stroke="#27272A"/>
+  <rect x="82" y="58" width="42" height="42" rx="14" fill="#EC4899"/>
+  <text x="142" y="87" fill="#FAFAFA" font-family="Inter, Arial" font-size="25" font-weight="800">Image Gallery</text>
+  <rect x="990" y="58" width="116" height="42" rx="16" fill="#27272A"/>
+  <text x="1030" y="85" fill="#FBCFE8" font-family="Inter, Arial" font-size="15" font-weight="800">Claro</text>
+  <rect x="72" y="150" width="1056" height="190" rx="34" fill="#18181B" opacity="0.9" stroke="#27272A"/>
+  <text x="110" y="204" fill="#F9A8D4" font-family="Inter, Arial" font-size="15" font-weight="900" letter-spacing="4">PORTFOLIO GALLERY</text>
+  <text x="110" y="258" fill="#FAFAFA" font-family="Inter, Arial" font-size="42" font-weight="900">Modo oscuro pulido</text>
+  <text x="110" y="296" fill="#D4D4D8" font-family="Inter, Arial" font-size="20">Interfaz responsive con filtros, favoritos e import/export JSON.</text>
+  <rect x="764" y="195" width="96" height="86" rx="24" fill="#09090B" stroke="#3F3F46"/>
+  <rect x="886" y="195" width="96" height="86" rx="24" fill="#09090B" stroke="#3F3F46"/>
+  <rect x="1008" y="195" width="96" height="86" rx="24" fill="#09090B" stroke="#3F3F46"/>
+  <text x="798" y="235" fill="#F472B6" font-family="Inter, Arial" font-size="34" font-weight="900">9</text>
+  <text x="908" y="235" fill="#F472B6" font-family="Inter, Arial" font-size="34" font-weight="900">3</text>
+  <text x="1030" y="235" fill="#F472B6" font-family="Inter, Arial" font-size="34" font-weight="900">9</text>
+  <text x="790" y="262" fill="#A1A1AA" font-family="Inter, Arial" font-size="14" font-weight="700">Imágenes</text>
+  <text x="902" y="262" fill="#A1A1AA" font-family="Inter, Arial" font-size="14" font-weight="700">Favoritas</text>
+  <text x="1030" y="262" fill="#A1A1AA" font-family="Inter, Arial" font-size="14" font-weight="700">Visibles</text>
+  <rect x="72" y="370" width="1056" height="92" rx="28" fill="#18181B" opacity="0.9" stroke="#27272A"/>
+  <rect x="104" y="394" width="390" height="44" rx="16" fill="#09090B" stroke="#3F3F46"/>
+  <text x="128" y="422" fill="#71717A" font-family="Inter, Arial" font-size="16">Buscar imágenes...</text>
+  <rect x="514" y="394" width="190" height="44" rx="16" fill="#09090B" stroke="#3F3F46"/>
+  <text x="538" y="422" fill="#E4E4E7" font-family="Inter, Arial" font-size="16">Todas</text>
+  <rect x="724" y="394" width="190" height="44" rx="16" fill="#09090B" stroke="#3F3F46"/>
+  <text x="748" y="422" fill="#E4E4E7" font-family="Inter, Arial" font-size="16">Orden manual</text>
+  <rect x="934" y="394" width="154" height="44" rx="16" fill="#EC4899"/>
+  <text x="972" y="422" fill="white" font-family="Inter, Arial" font-size="16" font-weight="800">Favoritas</text>
+  <g transform="translate(72 500)">
+    <rect width="324" height="188" rx="28" fill="#18181B" stroke="#27272A"/>
+    <rect width="324" height="188" rx="28" fill="url(#cardA)" opacity="0.9"/>
+    <rect x="18" y="122" width="78" height="28" rx="14" fill="white" opacity="0.18"/>
+    <text x="22" y="141" fill="white" font-family="Inter, Arial" font-size="13" font-weight="800">Paisaje</text>
+    <text x="20" y="169" fill="white" font-family="Inter, Arial" font-size="22" font-weight="900">Montaña Rosa</text>
+  </g>
+  <g transform="translate(438 500)">
+    <rect width="324" height="188" rx="28" fill="#18181B" stroke="#27272A"/>
+    <rect width="324" height="188" rx="28" fill="url(#cardB)" opacity="0.9"/>
+    <rect x="18" y="122" width="72" height="28" rx="14" fill="white" opacity="0.18"/>
+    <text x="22" y="141" fill="white" font-family="Inter, Arial" font-size="13" font-weight="800">Ciudad</text>
+    <text x="20" y="169" fill="white" font-family="Inter, Arial" font-size="22" font-weight="900">Ciudad Nocturna</text>
+  </g>
+  <g transform="translate(804 500)">
+    <rect width="324" height="188" rx="28" fill="#18181B" stroke="#27272A"/>
+    <rect width="324" height="188" rx="28" fill="url(#cardC)" opacity="0.9"/>
+    <rect x="18" y="122" width="64" height="28" rx="14" fill="white" opacity="0.18"/>
+    <text x="22" y="141" fill="white" font-family="Inter, Arial" font-size="13" font-weight="800">Viajes</text>
+    <text x="20" y="169" fill="white" font-family="Inter, Arial" font-size="22" font-weight="900">Playa Tranquila</text>
+  </g>
+  <defs>
+    <linearGradient id="cardA" x1="0" y1="0" x2="324" y2="188"><stop stop-color="#831843"/><stop offset="1" stop-color="#4338CA"/></linearGradient>
+    <linearGradient id="cardB" x1="0" y1="0" x2="324" y2="188"><stop stop-color="#020617"/><stop offset="1" stop-color="#BE185D"/></linearGradient>
+    <linearGradient id="cardC" x1="0" y1="0" x2="324" y2="188"><stop stop-color="#0F766E"/><stop offset="1" stop-color="#7C2D12"/></linearGradient>
+  </defs>
+</svg>

--- a/docs/preview/gallery-light.svg
+++ b/docs/preview/gallery-light.svg
@@ -1,0 +1,60 @@
+<svg width="1200" height="760" viewBox="0 0 1200 760" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Image Gallery App light preview</title>
+  <desc id="desc">Portfolio gallery preview with light theme, filters, cards and stats.</desc>
+  <rect width="1200" height="760" rx="36" fill="#FFF7FB"/>
+  <circle cx="1050" cy="120" r="210" fill="#F9A8D4" opacity="0.36"/>
+  <circle cx="150" cy="650" r="220" fill="#C4B5FD" opacity="0.34"/>
+  <rect x="56" y="42" width="1088" height="72" rx="24" fill="white" opacity="0.9"/>
+  <rect x="82" y="58" width="42" height="42" rx="14" fill="#EC4899"/>
+  <text x="142" y="87" fill="#18181B" font-family="Inter, Arial" font-size="25" font-weight="800">Image Gallery</text>
+  <rect x="990" y="58" width="116" height="42" rx="16" fill="#FCE7F3"/>
+  <text x="1020" y="85" fill="#BE185D" font-family="Inter, Arial" font-size="15" font-weight="800">Oscuro</text>
+  <rect x="72" y="150" width="1056" height="190" rx="34" fill="white" opacity="0.86"/>
+  <text x="110" y="204" fill="#BE185D" font-family="Inter, Arial" font-size="15" font-weight="900" letter-spacing="4">PORTFOLIO GALLERY</text>
+  <text x="110" y="258" fill="#18181B" font-family="Inter, Arial" font-size="42" font-weight="900">Galería visual con filtros</text>
+  <text x="110" y="296" fill="#52525B" font-family="Inter, Arial" font-size="20">Sube, edita, filtra y respalda imágenes con persistencia local.</text>
+  <rect x="764" y="195" width="96" height="86" rx="24" fill="#FFF1F2"/>
+  <rect x="886" y="195" width="96" height="86" rx="24" fill="#FFF1F2"/>
+  <rect x="1008" y="195" width="96" height="86" rx="24" fill="#FFF1F2"/>
+  <text x="798" y="235" fill="#EC4899" font-family="Inter, Arial" font-size="34" font-weight="900">9</text>
+  <text x="908" y="235" fill="#EC4899" font-family="Inter, Arial" font-size="34" font-weight="900">3</text>
+  <text x="1030" y="235" fill="#EC4899" font-family="Inter, Arial" font-size="34" font-weight="900">9</text>
+  <text x="790" y="262" fill="#71717A" font-family="Inter, Arial" font-size="14" font-weight="700">Imágenes</text>
+  <text x="902" y="262" fill="#71717A" font-family="Inter, Arial" font-size="14" font-weight="700">Favoritas</text>
+  <text x="1030" y="262" fill="#71717A" font-family="Inter, Arial" font-size="14" font-weight="700">Visibles</text>
+  <rect x="72" y="370" width="1056" height="92" rx="28" fill="white" opacity="0.9"/>
+  <rect x="104" y="394" width="390" height="44" rx="16" fill="#FAFAFA" stroke="#FBCFE8"/>
+  <text x="128" y="422" fill="#94A3B8" font-family="Inter, Arial" font-size="16">Buscar imágenes...</text>
+  <rect x="514" y="394" width="190" height="44" rx="16" fill="#FAFAFA" stroke="#E4E4E7"/>
+  <text x="538" y="422" fill="#52525B" font-family="Inter, Arial" font-size="16">Todas</text>
+  <rect x="724" y="394" width="190" height="44" rx="16" fill="#FAFAFA" stroke="#E4E4E7"/>
+  <text x="748" y="422" fill="#52525B" font-family="Inter, Arial" font-size="16">Orden manual</text>
+  <rect x="934" y="394" width="154" height="44" rx="16" fill="#EC4899"/>
+  <text x="972" y="422" fill="white" font-family="Inter, Arial" font-size="16" font-weight="800">Favoritas</text>
+  <g transform="translate(72 500)">
+    <rect width="324" height="188" rx="28" fill="#18181B"/>
+    <rect x="0" y="0" width="324" height="188" rx="28" fill="url(#cardA)"/>
+    <rect x="18" y="122" width="78" height="28" rx="14" fill="white" opacity="0.22"/>
+    <text x="22" y="141" fill="white" font-family="Inter, Arial" font-size="13" font-weight="800">Paisaje</text>
+    <text x="20" y="169" fill="white" font-family="Inter, Arial" font-size="22" font-weight="900">Montaña Rosa</text>
+  </g>
+  <g transform="translate(438 500)">
+    <rect width="324" height="188" rx="28" fill="#18181B"/>
+    <rect x="0" y="0" width="324" height="188" rx="28" fill="url(#cardB)"/>
+    <rect x="18" y="122" width="72" height="28" rx="14" fill="white" opacity="0.22"/>
+    <text x="22" y="141" fill="white" font-family="Inter, Arial" font-size="13" font-weight="800">Ciudad</text>
+    <text x="20" y="169" fill="white" font-family="Inter, Arial" font-size="22" font-weight="900">Ciudad Nocturna</text>
+  </g>
+  <g transform="translate(804 500)">
+    <rect width="324" height="188" rx="28" fill="#18181B"/>
+    <rect x="0" y="0" width="324" height="188" rx="28" fill="url(#cardC)"/>
+    <rect x="18" y="122" width="64" height="28" rx="14" fill="white" opacity="0.22"/>
+    <text x="22" y="141" fill="white" font-family="Inter, Arial" font-size="13" font-weight="800">Viajes</text>
+    <text x="20" y="169" fill="white" font-family="Inter, Arial" font-size="22" font-weight="900">Playa Tranquila</text>
+  </g>
+  <defs>
+    <linearGradient id="cardA" x1="0" y1="0" x2="324" y2="188"><stop stop-color="#F9A8D4"/><stop offset="1" stop-color="#6366F1"/></linearGradient>
+    <linearGradient id="cardB" x1="0" y1="0" x2="324" y2="188"><stop stop-color="#111827"/><stop offset="1" stop-color="#EC4899"/></linearGradient>
+    <linearGradient id="cardC" x1="0" y1="0" x2="324" y2="188"><stop stop-color="#38BDF8"/><stop offset="1" stop-color="#F97316"/></linearGradient>
+  </defs>
+</svg>

--- a/docs/preview/gallery-modal.svg
+++ b/docs/preview/gallery-modal.svg
@@ -1,0 +1,46 @@
+<svg width="1200" height="760" viewBox="0 0 1200 760" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Image Gallery App modal preview</title>
+  <desc id="desc">Image detail modal preview with editable fields and metadata.</desc>
+  <rect width="1200" height="760" rx="36" fill="#09090B"/>
+  <rect width="1200" height="760" rx="36" fill="#09090B" opacity="0.86"/>
+  <circle cx="1020" cy="130" r="240" fill="#BE185D" opacity="0.32"/>
+  <circle cx="160" cy="620" r="260" fill="#4F46E5" opacity="0.28"/>
+  <rect x="124" y="86" width="952" height="588" rx="36" fill="#FFFFFF"/>
+  <rect x="124" y="86" width="492" height="588" rx="36" fill="#18181B"/>
+  <path d="M124 122C124 102.118 140.118 86 160 86H616V674H160C140.118 674 124 657.882 124 638V122Z" fill="url(#photo)"/>
+  <rect x="124" y="86" width="492" height="588" rx="36" fill="url(#fade)"/>
+  <text x="170" y="588" fill="white" font-family="Inter, Arial" font-size="38" font-weight="900">Montaña Rosa</text>
+  <text x="170" y="626" fill="#FCE7F3" font-family="Inter, Arial" font-size="18" font-weight="700">Detalle visual con metadata editable</text>
+  <rect x="1016" y="116" width="38" height="38" rx="19" fill="#F4F4F5"/>
+  <text x="1027" y="143" fill="#52525B" font-family="Inter, Arial" font-size="24" font-weight="900">×</text>
+  <rect x="656" y="126" width="154" height="34" rx="17" fill="#FCE7F3"/>
+  <text x="680" y="148" fill="#BE185D" font-family="Inter, Arial" font-size="13" font-weight="900" letter-spacing="2">DETALLE</text>
+  <text x="656" y="200" fill="#52525B" font-family="Inter, Arial" font-size="14" font-weight="800">Título</text>
+  <rect x="656" y="214" width="364" height="56" rx="18" fill="#FAFAFA" stroke="#E4E4E7"/>
+  <text x="680" y="249" fill="#18181B" font-family="Inter, Arial" font-size="24" font-weight="900">Montaña Rosa</text>
+  <text x="656" y="306" fill="#52525B" font-family="Inter, Arial" font-size="14" font-weight="800">Descripción</text>
+  <rect x="656" y="320" width="364" height="100" rx="18" fill="#FAFAFA" stroke="#E4E4E7"/>
+  <text x="680" y="354" fill="#3F3F46" font-family="Inter, Arial" font-size="16">Amanecer suave entre montañas</text>
+  <text x="680" y="382" fill="#3F3F46" font-family="Inter, Arial" font-size="16">y tonos pastel.</text>
+  <text x="656" y="456" fill="#52525B" font-family="Inter, Arial" font-size="14" font-weight="800">Categoría</text>
+  <rect x="656" y="470" width="364" height="50" rx="18" fill="#FAFAFA" stroke="#E4E4E7"/>
+  <text x="680" y="502" fill="#18181B" font-family="Inter, Arial" font-size="16" font-weight="800">Paisaje</text>
+  <g transform="translate(656 544)">
+    <rect width="172" height="58" rx="16" fill="#FAFAFA" stroke="#E4E4E7"/>
+    <text x="16" y="23" fill="#A1A1AA" font-family="Inter, Arial" font-size="11" font-weight="900" letter-spacing="1.5">PESO</text>
+    <text x="16" y="43" fill="#18181B" font-family="Inter, Arial" font-size="15" font-weight="800">284.5 KB</text>
+  </g>
+  <g transform="translate(848 544)">
+    <rect width="172" height="58" rx="16" fill="#FAFAFA" stroke="#E4E4E7"/>
+    <text x="16" y="23" fill="#A1A1AA" font-family="Inter, Arial" font-size="11" font-weight="900" letter-spacing="1.5">FORMATO</text>
+    <text x="16" y="43" fill="#18181B" font-family="Inter, Arial" font-size="15" font-weight="800">image/webp</text>
+  </g>
+  <rect x="656" y="622" width="172" height="50" rx="18" fill="#EC4899"/>
+  <text x="686" y="654" fill="white" font-family="Inter, Arial" font-size="16" font-weight="900">Guardar</text>
+  <rect x="848" y="622" width="172" height="50" rx="18" fill="#F4F4F5"/>
+  <text x="904" y="654" fill="#DC2626" font-family="Inter, Arial" font-size="16" font-weight="900">Eliminar</text>
+  <defs>
+    <linearGradient id="photo" x1="124" y1="86" x2="616" y2="674"><stop stop-color="#F9A8D4"/><stop offset="0.52" stop-color="#818CF8"/><stop offset="1" stop-color="#312E81"/></linearGradient>
+    <linearGradient id="fade" x1="370" y1="220" x2="370" y2="674"><stop stop-color="#000000" stop-opacity="0"/><stop offset="1" stop-color="#000000" stop-opacity="0.72"/></linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary

- Adds lightweight SVG preview assets for the gallery.
- Adds light mode, dark mode and image detail modal previews.
- Updates README with a visual preview section.
- Documents image compression as part of the feature list.

## Related issue

Closes #18