### PR TITLE
test: add storage and component regression checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+      - name: Run tests
+        run: npm test
+
       - name: Build project
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "node scripts/storage-recovery.test.cjs && node scripts/component-regression.test.cjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/component-regression.test.cjs
+++ b/scripts/component-regression.test.cjs
@@ -1,0 +1,63 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+
+function readSource(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function test(name, assertion) {
+  try {
+    assertion();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+const gallery = readSource('src/components/Gallery.tsx');
+const modal = readSource('src/components/ImageModal.tsx');
+const card = readSource('src/components/ImageCard.tsx');
+const compression = readSource('src/utils/imageCompression.ts');
+
+test('gallery keeps search and filtering controls', () => {
+  assert.match(gallery, /placeholder="Buscar por título, descripción o categoría\.\.\."/);
+  assert.match(gallery, /setCategoryFilter/);
+  assert.match(gallery, /setShowFavoritesOnly/);
+});
+
+test('gallery keeps import and export actions', () => {
+  assert.match(gallery, /Exportar JSON/);
+  assert.match(gallery, /Importar JSON/);
+  assert.match(gallery, /handleImport/);
+  assert.match(gallery, /exportGallery/);
+});
+
+test('gallery compresses uploads before saving', () => {
+  assert.match(gallery, /compressImageFile/);
+  assert.match(gallery, /Optimizando imagen/);
+  assert.match(compression, /canvas\.toBlob/);
+});
+
+test('modal keeps keyboard and unsaved changes protection', () => {
+  assert.match(modal, /KeyboardEvent/);
+  assert.match(modal, /Escape/);
+  assert.match(modal, /Tienes cambios sin guardar/);
+});
+
+test('image card keeps favorite action accessibility', () => {
+  assert.match(card, /aria-pressed/);
+  assert.match(card, /Marcar como favorita/);
+  assert.match(card, /Quitar de favoritas/);
+});
+
+test('gallery keeps empty state guidance', () => {
+  assert.match(gallery, /Tu galería está vacía/);
+  assert.match(gallery, /No encontramos resultados/);
+  assert.match(gallery, /Limpiar filtros/);
+});
+
+console.log('component regression checks completed');

--- a/scripts/storage-recovery.test.cjs
+++ b/scripts/storage-recovery.test.cjs
@@ -1,0 +1,44 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const sourcePath = path.resolve(__dirname, '..', 'src', 'utils', 'gallery.ts');
+const source = fs.readFileSync(sourcePath, 'utf8');
+
+function test(name, assertion) {
+  try {
+    assertion();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+test('storage loader exists', () => {
+  assert.match(source, /export function loadImagesFromStorage/);
+});
+
+test('storage loader protects JSON parsing', () => {
+  assert.match(source, /try\s*{/);
+  assert.match(source, /JSON\.parse/);
+  assert.match(source, /catch\s*{/);
+});
+
+test('invalid storage is removed after recovery', () => {
+  assert.match(source, /localStorage\.removeItem\(storageKey\)/);
+});
+
+test('fallback images are normalized before returning', () => {
+  assert.match(source, /normalizeImages\(fallback\)/);
+});
+
+test('saved values must be arrays', () => {
+  assert.match(source, /Array\.isArray\(parsed\)/);
+});
+
+test('image urls are validated during normalization', () => {
+  assert.match(source, /isSafeImageUrl\(url\)/);
+});
+
+console.log('storage recovery regression checks completed');


### PR DESCRIPTION
## Summary

- Adds storage recovery regression checks for the gallery utilities.
- Adds component regression checks for filters, import/export, compression, modal behavior, favorites and empty states.
- Adds an `npm test` script without new dependencies, keeping the current lockfile stable.
- Runs tests in CI before the production build.

## Related issues

Closes #6
Refs #7