### PR TITLE
ci: deploy GitHub Pages from main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
       - develop
   workflow_dispatch:
 
@@ -35,18 +40,24 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+      - name: Run tests
+        run: npm test
+
       - name: Build project
         run: npm run build -- --base=/image-gallery-app/
 
       - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary

- Enables GitHub Pages deploy on pushes to `main` and `develop`.
- Adds PR validation for the deploy workflow without publishing artifacts.
- Runs tests before the Pages build.

## Why

The production merge landed on `main`, but the deploy workflow only listened to `develop`, so GitHub Pages did not publish the app after production release.